### PR TITLE
Onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "electron-default-menu": "^1.0.1",
     "electron-google-auth": "^0.0.1",
     "electron-oauth2": "^3.0.0",
+    "fs-extra": "^7.0.1",
     "googleapis": "^23.0.0",
     "lunr": "^2.1.0",
     "markdown-it": "^8.3.1",

--- a/resources/public/css/main.css
+++ b/resources/public/css/main.css
@@ -258,7 +258,7 @@ html {
 html {
   font-size: 16px;
   -ms-overflow-style: scrollbar;
-  -webkit-tap-highlight-color: transparent; }
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -427,7 +427,9 @@ h1, h2, h3, h4, h5, h6,
   line-height: 1.1;
   color: inherit; }
 
-h1, .h1, .cm-header-1 {
+h1,
+.h1,
+.cm-header-1 {
   font-size: 2.5rem; }
 
 h2, .h2, .cm-header-2 {
@@ -4313,7 +4315,7 @@ button.close {
     margin: 1px;
     text-indent: -999px;
     cursor: pointer;
-    background-color: transparent;
+    background-color: rgba(0, 0, 0, 0);
     border: 1px solid #fff;
     border-radius: 10px; }
   .carousel-indicators .active {
@@ -6614,15 +6616,16 @@ img.emoji {
   display: inline; }
 
 .btn-default {
+  margin-bottom: 10px;
   border: 1px solid #5CB91C;
   color: #5CB91C;
-  background: transparent;
+  background: rgba(0, 0, 0, 0);
   outline: none; }
 
 .btn-default:focus {
   border: 1px solid #5CB91C;
   color: #5CB91C;
-  background: transparent;
+  background: rgba(0, 0, 0, 0);
   outline: none; }
 
 .btn-default:hover {
@@ -6648,13 +6651,13 @@ img.emoji {
 .btn-danger {
   border: 1px solid #d9534f;
   color: #d9534f;
-  background: transparent;
+  background: rgba(0, 0, 0, 0);
   outline: none; }
 
 .btn-danger:focus {
   border: 1px solid #d9534f;
   color: #d9534f;
-  background: transparent;
+  background: rgba(0, 0, 0, 0);
   outline: none; }
 
 .btn-danger:hover {
@@ -6689,7 +6692,7 @@ img.emoji {
 .btn-tag:focus {
   border: 1px solid #E4E4E4;
   color: #E4E4E4;
-  background: transparent;
+  background: rgba(0, 0, 0, 0);
   outline: none; }
 
 .btn-tag:hover {

--- a/resources/src/styles.scss
+++ b/resources/src/styles.scss
@@ -271,6 +271,7 @@ img.emoji {
 }
 
 .btn-default {
+    margin-bottom: 10px;
     border: 1px solid #5CB91C;
     color: #5CB91C;
     background: rgba(0,0,0,0.0);

--- a/src/cljs/kiwi/core.cljs
+++ b/src/cljs/kiwi/core.cljs
@@ -85,7 +85,8 @@
   (enable-console-print!)
   (set! *warn-on-infer* true)
   (hook-browser-navigation!)
-  (let [wiki-root-dir (storage/load "wiki-root-dir")
+  (let [wiki-root-d (storage/load "wiki-root-dir")
+        wiki-root-dir (if (= "null" wiki-root-d) nil wiki-root-d)
         google-access-token (storage/load "google-access-token")]
     (dispatch-sync [:initialize
                     {:wiki-root-dir wiki-root-dir
@@ -93,6 +94,7 @@
     (register-keybindings!)
 
     (if (not (nil? wiki-root-dir))
-      (dispatch [:set-route (routes/page-route {:permalink "home"})])
-      (dispatch [:set-route (routes/settings-route)]))
+      (dispatch-sync [:set-route (routes/page-route {:permalink "home"})])
+      (dispatch-sync [:set-route (routes/settings-route)]))
     (render)))
+

--- a/src/cljs/kiwi/core.cljs
+++ b/src/cljs/kiwi/core.cljs
@@ -16,6 +16,7 @@
             [kiwi.editor.views]
             [kiwi.search.views]
             [kiwi.settings.views]
+            [kiwi.setup.views]
             [kiwi.page.views]
             [kiwi.page.modals]
             [kiwi.views :as views]

--- a/src/cljs/kiwi/handlers.cljs
+++ b/src/cljs/kiwi/handlers.cljs
@@ -9,6 +9,7 @@
             [kiwi.editor.events]
             [kiwi.search.events]
             [kiwi.settings.events]
+            [kiwi.setup.events]
             [kiwi.page.events]
             [re-frame.core
              :as

--- a/src/cljs/kiwi/keybindings.cljs
+++ b/src/cljs/kiwi/keybindings.cljs
@@ -21,48 +21,62 @@
 
 (def keybindings
   [{:key "e"
+    :description "Enter edit mode"
     :keymap :local
     :handler #(when (not @(subscribe [:editing?]))
                 (toggle-editing!))}
    {:key "i"
+    :description "Enter edit mode"
     :keymap :local
     :handler #(when (not @(subscribe [:editing?]))
                 (toggle-editing!))}
 
    {:key "command+enter"
+    :description "Toggle edit mode"
     :keymap :global
     :handler toggle-editing!}
    {:key "g s"
+    :description "Go to search"
     :keymap :local
     :handler #(dispatch [:set-route (routes/search-route)])}
    {:key "g h"
+    :description "Go to home"
     :keymap :local
     :handler #(dispatch [:set-route (routes/page-route {:permalink "home"})])}
    {:key "n"
+    :description "Add new page"
     :keymap :local
     :handler #(dispatch [:show-modal :add-page])}
    {:key "esc"
+    :description "Escape"
     :keymap :global
     :handler escape!}
    {:key "ctrl+["
+    :description "Escape"
     :keymap :global
     :handler escape!}
    {:key "u"
+    :description "Scroll up by one page"
     :keymap :local
     :handler #(.scrollBy js/window 0 (- page-scroll-by))}
    {:key "d"
+    :description "Scroll down by one page"
     :keymap :local
     :handler #(.scrollBy js/window 0 page-scroll-by)}
    {:key "j"
+    :description "Scroll down"
     :keymap :local
     :handler #(.scrollBy js/window 0 scroll-by)}
    {:key "k"
+    :description "Scroll up"
     :keymap :local
     :handler #(.scrollBy js/window 0 (- scroll-by))}
    {:key "H"
+    :description "Go back"
     :keymap :local
     :handler #(.back js/window.history)}
    {:key "L"
+    :description "Go forward"
     :keymap :local
     :handler #(.forward js/window.history)}])
 

--- a/src/cljs/kiwi/settings/subs.cljs
+++ b/src/cljs/kiwi/settings/subs.cljs
@@ -1,16 +1,21 @@
 (ns kiwi.settings.subs
-  (:require [re-frame.core :as re-frame :refer [reg-sub]]))
+  (:require [re-frame.core :as re-frame :refer [reg-sub]]
+            [re-frame.db :refer [app-db]]
+            [kiwi.setup.utils :as setup-utils]))
 
 (reg-sub
  :wiki-root-dir
  (fn [db _]
    (get-in db [:wiki-root-dir])))
 
+(defn configured? [db _]
+  (let [wiki-root-dir (get-in db [:wiki-root-dir])]
+    (and
+     (not (nil? wiki-root-dir)))))
+
 (reg-sub
  :configured?
- :<- [:wiki-root-dir]
- (fn [[wiki-root-dir] _]
-   (not (nil? wiki-root-dir))))
+ configured?)
 
 (reg-sub
  :google-access-token

--- a/src/cljs/kiwi/settings/subs.cljs
+++ b/src/cljs/kiwi/settings/subs.cljs
@@ -7,6 +7,12 @@
    (get-in db [:wiki-root-dir])))
 
 (reg-sub
+ :configured?
+ :<- [:wiki-root-dir]
+ (fn [[wiki-root-dir] _]
+   (not (nil? wiki-root-dir))))
+
+(reg-sub
  :google-access-token
  (fn [db _]
    (get-in db [:google-access-token])))

--- a/src/cljs/kiwi/settings/views.cljs
+++ b/src/cljs/kiwi/settings/views.cljs
@@ -114,7 +114,9 @@
          (if (not (nil? @wiki-root-dir))
            [:section
             [:p "Your wiki is located at "[ :code @wiki-root-dir]]
-            [set-wiki-root-button "Choose different location"]]
+            [:button.btn.btn-default
+             {:on-click #(dispatch [:assoc-wiki-root-dir nil])}
+             "Unlink wiki"]]
            [setup])]
         
         (when features/schedule-enabled?

--- a/src/cljs/kiwi/settings/views.cljs
+++ b/src/cljs/kiwi/settings/views.cljs
@@ -63,8 +63,7 @@
              [:p "Kiwi is configured to use your wiki located at " [:code @wiki-root-dir] "."]
              [:button.btn.btn-default
               {:on-click #(dispatch [:assoc-wiki-root-dir nil])}
-              "Unlink wiki"]]
-            [kiwi.setup.views/setup])]]
+              "Unlink wiki"]])]]
         
         (when features/schedule-enabled?
           [:section

--- a/src/cljs/kiwi/settings/views.cljs
+++ b/src/cljs/kiwi/settings/views.cljs
@@ -13,26 +13,6 @@
    [reagent.ratom :refer [reaction]])
   )
 
-(def electron (js/require "electron"))
-(def shell (.-shell electron))
-(def remote (.-remote electron))
-(def dialog (.-dialog remote))
-
-(def fs (js/require "fs"))
-(def os (js/require "os"))
-
-
-(defn set-wiki-root-button [text]
-  (let [on-directory-chosen
-        (fn [directories]
-          (when (seq directories)
-            (dispatch [:assoc-wiki-root-dir (first (js->clj directories))])))]
-    [:button.btn.btn-default
-      {:on-click (fn [_]
-                   (.showOpenDialog dialog
-                                    (clj->js {:properties ["openDirectory"]})
-                                    on-directory-chosen))}
-      text]))
 
 
 (defn link-with-google-button
@@ -49,43 +29,8 @@
 
 #_(dispatch [:assoc-wiki-root-dir nil])
 
-(def default-wiki-path
-  (str (.-homedir (.userInfo os)) "/Dropbox/Apps/KiwiApp"))
 
-(defn file-exists? [path]
-  (try
-    (do
-      (.accessSync fs path)
-      true)
-    (catch :default e
-      false)))
 
-(defn auto-setup-alert []
-  [re-com/alert-box
-   :alert-type :info
-   :heading "Already have a wiki?"
-   :body [:div
-          [:p "It looks like you already have a wiki at " [:code default-wiki-path] "."]
-          [:p "Would you like to use this wiki?"]
-          [:button.btn.btn-default
-           {:on-click #(dispatch [:assoc-wiki-root-dir default-wiki-path])}
-           "Yes, please!"]]])
-
-(defn setup []
-  (fn []
-    [:section
-     [:h2 "Setup"]
-     (when (file-exists? default-wiki-path)
-       [auto-setup-alert])
-
-     [:div
-      [:p
-       "Configure Kiwi by telling it where to find your wiki. If you use Kiwi for iOS, your wiki is located at "
-       [:code "/Users/you/Dropbox/Apps/KiwiApp"]
-       "."]
-      [:div.btn-group
-       [set-wiki-root-button "Find existing wiki"]
-       [:button.btn.btn-default "Create new wiki"]]]]))
 
 (defn keybindings-help []
   [:section
@@ -111,13 +56,15 @@
         [:section 
          [:h1.post-title "Settings"]
 
-         (if (not (nil? @wiki-root-dir))
-           [:section
-            [:p "Your wiki is located at "[ :code @wiki-root-dir]]
-            [:button.btn.btn-default
-             {:on-click #(dispatch [:assoc-wiki-root-dir nil])}
-             "Unlink wiki"]]
-           [setup])]
+         [:section
+          [:h2 "Setup"]
+          (if (not (nil? @wiki-root-dir))
+            [:div
+             [:p "Kiwi is configured to use your wiki located at " [:code @wiki-root-dir] "."]
+             [:button.btn.btn-default
+              {:on-click #(dispatch [:assoc-wiki-root-dir nil])}
+              "Unlink wiki"]]
+            [kiwi.setup.views/setup])]]
         
         (when features/schedule-enabled?
           [:section

--- a/src/cljs/kiwi/settings/views.cljs
+++ b/src/cljs/kiwi/settings/views.cljs
@@ -4,6 +4,7 @@
 
    [kiwi.google-calendar :as google-calendar]
    [kiwi.views :as views]
+   [kiwi.keybindings :as keybindings]
    [kiwi.features :as features]
    [cljs.core.async :as async])
   (:require-macros
@@ -41,6 +42,20 @@
    [link-with-google-button "Link with Google"]))
 
 
+(defn keybindings-help []
+  [:section
+   [:h2 "Keybindings"]
+   [:p "Kiwi has a number of built-in " [:a {:href "https://www.vim.org/" :target "_blank"} "vim"] "-esque keybindings, for those who are keyboard-inclined."]
+   [:table.table
+    [:thead
+     [:tr
+      [:th "Key"]
+      [:th "Description"]]]
+    [:tbody
+     (for [keybinding keybindings/keybindings]
+       [:tr
+        [:th [:code (:key keybinding)]]
+        [:th (:description keybinding)]])]]])
 (defn settings-page []
   (let [wiki-root-dir (subscribe [:wiki-root-dir])
         google-access-token (subscribe [:google-access-token])]
@@ -60,5 +75,7 @@
              [:div 
               [:p "Already linked with Google."]
               [link-with-google-button "Re-link with Google"]]
-             [link-with-google-button])])]])))
+             [link-with-google-button])])
+
+        #_[keybindings-help]]])))
 

--- a/src/cljs/kiwi/settings/views.cljs
+++ b/src/cljs/kiwi/settings/views.cljs
@@ -75,5 +75,5 @@
               [link-with-google-button "Re-link with Google"]]
              [link-with-google-button])])
 
-        #_[keybindings-help]]])))
+        [keybindings-help]]])))
 

--- a/src/cljs/kiwi/setup/events.cljs
+++ b/src/cljs/kiwi/setup/events.cljs
@@ -1,0 +1,2 @@
+(ns kiwi.setup.events)
+

--- a/src/cljs/kiwi/setup/events.cljs
+++ b/src/cljs/kiwi/setup/events.cljs
@@ -1,2 +1,64 @@
-(ns kiwi.setup.events)
+(ns kiwi.setup.events
+  (:require
+   [re-frame.core
+    :as
+    re-frame
+    :refer
+    [dispatch after enrich path reg-event-db reg-event-fx reg-fx]]
+   [kiwi.setup.utils :as setup-utils]))
 
+(def fs (js/require "fs-extra"))
+
+(reg-event-fx
+ :navigate-setup
+ (fn [{:keys [db]} [_ route]]
+   {:db
+    (-> db
+        (assoc :setup-state {:route route}))}))
+
+(defn create-wiki-dirs [root-dir]
+  (fs.mkdirpSync (str root-dir "/public/img"))
+  (fs.mkdirpSync (str root-dir "/wiki")))
+
+;; TODO: Replace with reading home file + other tutorial files
+;;
+;; Electron Builder's extraResources or extraFiles options
+;; seems like the right way to get default pages into the app.
+;;
+;; The following link indicates that one should be able to use
+;; `process.resourcesPath` to access the resources directory.
+;;
+;; The annoying thing is that process.resourcesPath references
+;; /usr/lib/electron/resources when using `electron .`, so I
+;; guess we'll have to deal with that.
+;; 
+;; https://discuss.atom.io/t/cant-find-file-when-using-fs-readfilesync-from-packaged-electron-app/24854/4
+
+(def home-contents
+  (str "## Welcome to Kiwi!\n\n"
+       "This is your home page.\n\n"))
+
+(defn create-default-home-page [root-dir]
+  (let [home-path (str root-dir "/wiki/home.md")]
+    (when (not (setup-utils/file-exists? home-path))
+      (fs.writeFileSync home-path home-contents))))
+
+(reg-event-fx 
+ :finish-setup
+ (fn [{:keys [db]} [_ root-dir]]
+   (dispatch [:assoc-wiki-root-dir root-dir])
+   (dispatch [:show-page "home"])
+   {:db (dissoc db :setup-state)}))
+
+(reg-fx
+ :set-up-wiki
+ (fn [root-dir]
+   (create-wiki-dirs root-dir)
+   (create-default-home-page root-dir)
+   (dispatch [:finish-setup root-dir])))
+
+(reg-event-fx
+ :set-up-wiki
+ (fn [{:keys [db]} [_ root-dir]]
+   {:db db
+    :set-up-wiki root-dir}))

--- a/src/cljs/kiwi/setup/events.cljs
+++ b/src/cljs/kiwi/setup/events.cljs
@@ -10,6 +10,18 @@
 (def fs (js/require "fs-extra"))
 
 (reg-event-fx
+ :navigate-setup-next
+ (fn [{:keys [db]} [_]]
+   (let [route
+         (if (setup-utils/valid-wiki? setup-utils/default-wiki-path)
+           :find-wiki
+           :create-wiki)]
+     {:db
+      (-> db
+          (assoc :setup-state {:route route}))})))
+
+
+(reg-event-fx
  :navigate-setup
  (fn [{:keys [db]} [_ route]]
    {:db

--- a/src/cljs/kiwi/setup/subs.cljs
+++ b/src/cljs/kiwi/setup/subs.cljs
@@ -1,2 +1,8 @@
-(ns kiwi.setup.subs)
+(ns kiwi.setup.subs
+  (:require [re-frame.core :as re-frame :refer [reg-sub]]))
+
+(reg-sub
+ :setup-route
+ (fn [db _]
+   (get-in db [:setup-state :route])))
 

--- a/src/cljs/kiwi/setup/subs.cljs
+++ b/src/cljs/kiwi/setup/subs.cljs
@@ -1,0 +1,2 @@
+(ns kiwi.setup.subs)
+

--- a/src/cljs/kiwi/setup/utils.cljs
+++ b/src/cljs/kiwi/setup/utils.cljs
@@ -1,0 +1,26 @@
+(ns kiwi.setup.utils)
+
+(def electron (js/require "electron"))
+(def shell (.-shell electron))
+(def remote (.-remote electron))
+(def dialog (.-dialog remote))
+
+(def fs (js/require "fs"))
+(def os (js/require "os"))
+
+(def default-dropbox-path
+  (str (.-homedir (.userInfo os)) "/Dropbox"))
+(def default-wiki-path
+  (str default-dropbox-path "/Apps/KiwiApp"))
+
+(defn file-exists? [path]
+  (try
+    (do
+      (.accessSync fs path)
+      true)
+    (catch :default e
+      false)))
+
+(defn valid-wiki? [path]
+  (let [sentinal (str path "/wiki/home.md")]
+    (file-exists? sentinal)))

--- a/src/cljs/kiwi/setup/views.cljs
+++ b/src/cljs/kiwi/setup/views.cljs
@@ -1,0 +1,84 @@
+(ns kiwi.setup.views
+  (:require
+   [re-frame.core :as re-frame :refer [dispatch subscribe]]
+   [re-com.core :as re-com]))
+
+(def electron (js/require "electron"))
+(def shell (.-shell electron))
+(def remote (.-remote electron))
+(def dialog (.-dialog remote))
+
+(def fs (js/require "fs"))
+(def os (js/require "os"))
+(def default-wiki-path
+  (str (.-homedir (.userInfo os)) "/Dropbox/Apps/KiwiApp"))
+
+(defn file-exists? [path]
+  (try
+    (do
+      (.accessSync fs path)
+      true)
+    (catch :default e
+      false)))
+
+(defn auto-setup-alert []
+  [re-com/alert-box
+   :alert-type :info
+   :heading "Wiki auto-detected."
+   :body [:div
+          [:p "Looks like you already have a wiki at " [:code default-wiki-path] "."]
+          [:p "Would you like to configure Kiwi to use this wiki?"]
+          [:button.btn.btn-default
+           {:on-click #(dispatch [:assoc-wiki-root-dir default-wiki-path])}
+           "Yes, please!"]]])
+
+(defn set-wiki-root-button [text]
+  (let [on-directory-chosen
+        (fn [directories]
+          (when (seq directories)
+            (dispatch [:assoc-wiki-root-dir (first (js->clj directories))])))]
+    [:button.btn.btn-default
+      {:on-click (fn [_]
+                   (.showOpenDialog dialog
+                                    (clj->js {:properties ["openDirectory"]})
+                                    on-directory-chosen))}
+      text]))
+
+
+(defn setup []
+  (fn []
+    [:section
+     (when (file-exists? default-wiki-path)
+       [auto-setup-alert])
+
+     [:div
+      [:p
+       "Configure Kiwi by telling it where to find your wiki. If you use Kiwi for iOS, your wiki is located at "
+       [:code "/Users/you/Dropbox/Apps/KiwiApp"]
+       "."]
+      [:div.btn-group
+       [set-wiki-root-button "Find existing wiki"]
+       [:button.btn.btn-default "Create new wiki"]]]]))
+
+(defn marketing-materials []
+  (fn []
+    [:div
+     [:p "Kiwi is your personal wiki. You can use it to write, edit, and reflect on your thoughts. You might already use an app for taking notes, so here's why it's different:"]
+     [:ul
+      [:li "Link your notes together in whatever way makes sense to you instead of viewing them chronologically - you control the format."]
+      [:li "Search your notes quickly and easily - find what you need."]
+      [:li "Write your notes in markdown. No more WYSIWYG editors that don't do what you want."]
+      [:li "Add photos, links, math notation, code snippets, and checkboxes. Flexibility is the name of the game."]
+      [:li "Take your notes with you. Kiwi works offline and syncs automatically with Dropbox - you own your notes."]
+      ]]))
+
+(defn setup-page []
+  (fn []
+    [:article#page.settings
+      [:section
+       [:h1.post-title "Welcome to Kiwi!"]
+       [marketing-materials]
+
+       [:section
+        [:h2 "Setup"]
+        [setup]]]]))

--- a/src/cljs/kiwi/setup/views.cljs
+++ b/src/cljs/kiwi/setup/views.cljs
@@ -58,7 +58,7 @@
    [:h1.post-title "Welcome to Kiwi!"]
    [marketing-materials]
    [:button.btn.btn-default
-    {:on-click #(dispatch [:navigate-setup :find-wiki])}
+    {:on-click #(dispatch [:navigate-setup-next])}
     "Set up"]])
 
 (defn auto-wiki-setup []
@@ -101,11 +101,7 @@
 (defn find-wiki []
   (fn []
     [:section
-     (if (setup-utils/valid-wiki? setup-utils/default-wiki-path)
-       [auto-wiki-setup]
-       ;; TODO: could put this in a handler by just having it decide what to do
-       ;; and using an event like :navigate-setup-next or something
-       (dispatch [:navigate-setup :create-wiki]))]))
+     [auto-wiki-setup]]))
 
 
 (defn setup-page []

--- a/src/cljs/kiwi/subs.cljs
+++ b/src/cljs/kiwi/subs.cljs
@@ -5,6 +5,7 @@
             [kiwi.editor.subs]
             [kiwi.search.subs]
             [kiwi.settings.subs]
+            [kiwi.setup.subs]
             [kiwi.page.subs]
             [clojure.string :as string]))
 

--- a/src/cljs/kiwi/views.cljs
+++ b/src/cljs/kiwi/views.cljs
@@ -60,17 +60,19 @@
   (let [modal (subscribe [:modal])
         configured? (subscribe [:configured?])]
     (fn [content] 
-      (if (not @configured?)
-        [:div
-         [:div.header]
-         [:section.content-wrapper
-          [:div.content
-           [kiwi.setup.views/setup-page]]]]
+      [:div
+       (if (not @configured?)
+         [:div
+          [:div.header]
+          [:section.content-wrapper
+           [:div.content
+            [kiwi.setup.views/setup-page]]]]
 
-        [:div
-         [layout-header]
-         [:section.content-wrapper
-          [:div.content
-           content]]
-         (when @modal
-           (modals @modal))]))))
+         [:div
+          [layout-header]
+          [:section.content-wrapper
+           [:div.content
+            content]]])
+       (when @modal
+         (modals @modal))])))
+

--- a/src/cljs/kiwi/views.cljs
+++ b/src/cljs/kiwi/views.cljs
@@ -57,12 +57,20 @@
    :backdrop-on-click #(dispatch [:hide-modal])])
 
 (defn base-layout [content]
-  (let [modal (subscribe [:modal])]
+  (let [modal (subscribe [:modal])
+        configured? (subscribe [:configured?])]
     (fn [content] 
-      [:div
-       [layout-header]
-       [:section.content-wrapper
-        [:div.content
-         content]]
-       (when @modal
-         (modals @modal))])))
+      (if (not @configured?)
+        [:div
+         [:div.header]
+         [:section.content-wrapper
+          [:div.content
+           [kiwi.setup.views/setup-page]]]]
+
+        [:div
+         [layout-header]
+         [:section.content-wrapper
+          [:div.content
+           content]]
+         (when @modal
+           (modals @modal))]))))

--- a/src/cljs/kiwi/views.cljs
+++ b/src/cljs/kiwi/views.cljs
@@ -1,9 +1,9 @@
 (ns kiwi.views
   (:require 
    [re-frame.core :as re-frame :refer [after dispatch dispatch-sync enrich path register-handler register-sub subscribe]]
-   [kiwi.routes :as routes]
    [re-com.core :as re-com]
    [clojure.string :as string]
+   [kiwi.routes :as routes]
    [kiwi.page.core :as page]
    [kiwi.db :as page-db]
    [kiwi.features :as features])

--- a/test/cljs/kiwi/handlers_test.cljs
+++ b/test/cljs/kiwi/handlers_test.cljs
@@ -1,6 +1,7 @@
 (ns kiwi.handlers-test
   (:require [kiwi.handlers :as sut]
             [kiwi.core]
+            [kiwi.test.utils :as t]
             [re-frame.core :as r] 
             [day8.re-frame.test :as rf-test]
             [devcards.core :refer-macros [deftest]]
@@ -30,14 +31,10 @@
        (r/dispatch [:navigate [:some-page] {:path ""}])
        (is (= @current-route [:some-page]))))))
 
-(defn capture-into [atm]
-  (fn [arg]
-    (reset! atm arg)))
-
 (deftest test-set-route
   (let [arg (atom nil)]
     (rf-test/run-test-sync
-     (r/reg-fx :set-hash (capture-into arg))
+     (r/reg-fx :set-hash (t/capture-into arg))
      (r/dispatch [:initialize])
 
      (testing "causes a set-hash effect"
@@ -58,7 +55,7 @@
 (deftest test-assoc-google-access-token
   (let [arg (atom nil)]
     (rf-test/run-test-sync
-     (r/reg-fx :storage-save (capture-into arg))
+     (r/reg-fx :storage-save (t/capture-into arg))
      (r/dispatch [:initialize])
 
      (testing "sets access token in state and saves to storage"

--- a/test/cljs/kiwi/setup/events_test.cljs
+++ b/test/cljs/kiwi/setup/events_test.cljs
@@ -1,0 +1,75 @@
+(ns kiwi.setup.events-test
+  (:require [kiwi.setup.events :as sut]
+            [kiwi.test.utils :as t]
+            [cljs.test :refer-macros [is testing run-tests]]
+            [devcards.core :refer-macros [deftest]]
+            [day8.re-frame.test :as rf-test]
+            [re-frame.core :as r]
+            [kiwi.utils :as utils]))
+
+
+(deftest test-navigate-setup-next
+  (rf-test/run-test-sync
+   (r/reg-cofx
+    :default-wiki-path
+    #(assoc % :default-wiki-path "/test"))
+
+   (r/dispatch [:initialize])
+
+   (let [route (r/subscribe [:setup-route])]
+     (testing "with valid default wiki path"
+       (r/reg-cofx
+        :valid-wiki?
+        #(assoc % :valid-wiki? (fn [p] true)))
+
+       (testing "routes to :find-wiki"
+         (r/dispatch [:navigate-setup-next])
+         (is (= @route :find-wiki))))
+
+     (testing "with invalid default wiki path"
+       (r/reg-cofx
+        :valid-wiki?
+        #(assoc % :valid-wiki? (fn [p] false)))
+
+       (testing "routes to :create-wiki"
+         (r/dispatch [:navigate-setup-next])
+         (is (= @route :create-wiki)))))))
+
+(deftest test-navigate-setup
+  (rf-test/run-test-sync
+   (r/dispatch [:initialize])
+
+   (let [route (r/subscribe [:setup-route])]
+     (testing "sets route"
+       (r/dispatch [:navigate-setup :test-route])
+       (is (= @route :test-route))))))
+
+(deftest test-set-up-wiki
+  (let [arg (atom nil)]
+    (rf-test/run-test-sync
+     (r/reg-fx :set-up-wiki (t/capture-into arg))
+
+     (r/dispatch [:initialize])
+
+     (testing "causes a set-up-wiki effect"
+       (r/dispatch [:set-up-wiki "/test"])
+       (is (= @arg "/test"))))))
+
+(deftest test-finish-setup
+  (let [arg (atom nil)]
+    (rf-test/run-test-sync
+     (r/reg-fx :dispatch-n (t/capture-into arg))
+
+     (r/dispatch [:initialize])
+
+     (let [setup-route (r/subscribe [:setup-route])]
+       (r/dispatch [:finish-setup "/test"])
+
+       (testing "exits setup"
+         (is (= @setup-route nil)))
+
+       (testing "dispatches event to assoc wiki-root-dir"
+         (is (utils/in? @arg [:assoc-wiki-root-dir "/test"])))
+
+       (testing "dispatches event to navigate to wiki home"
+         (is (utils/in? @arg [:show-page "home"])))))))

--- a/test/cljs/kiwi/tests.cljs
+++ b/test/cljs/kiwi/tests.cljs
@@ -2,10 +2,12 @@
   (:require [cljs.test :refer-macros [run-tests run-all-tests]]
             [kiwi.handlers-test]
             [kiwi.settings.events-test]
+            [kiwi.setup.events-test]
             [kiwi.editor.events-test]))
 
 
 (defn run []
   (run-tests 'kiwi.handlers-test
              'kiwi.settings.events-test
+             'kiwi.setup.events-test
              'kiwi.editor.events-test))

--- a/test/cljs/kiwi/utils.cljs
+++ b/test/cljs/kiwi/utils.cljs
@@ -1,0 +1,5 @@
+(ns kiwi.test.utils)
+
+(defn capture-into [atm]
+  (fn [arg]
+    (reset! atm arg)))


### PR DESCRIPTION
Instead of starting _in media res_, we now have a separate onboarding flow. 

* Is triggered when no wiki root directory is present
* Walks you through linking an existing or creating a new wiki
  * Creates `home.md` for you (currently hardcoded) and wiki directory structure
* Is a little clunky and needs some design love but it works

![deepinscreenshot_kiwi_20181226121727](https://user-images.githubusercontent.com/700616/50456538-046bb000-090a-11e9-9567-89841571234d.png)
![deepinscreenshot_kiwi_20181226121827](https://user-images.githubusercontent.com/700616/50456539-046bb000-090a-11e9-96b5-e9d470265e2c.png)
![deepinscreenshot_kiwi_20181226121834](https://user-images.githubusercontent.com/700616/50456540-046bb000-090a-11e9-880b-e9f74fe0b1b4.png)