### PR TITLE
Drag and drop images into page editor

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -19,10 +19,10 @@
         </section>
       </div>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/codemirror.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/addon/mode/overlay.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/mode/markdown/markdown.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.7.0/mode/gfm/gfm.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.45.0/codemirror.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.45.0/addon/mode/overlay.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.45.0/mode/markdown/markdown.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.45.0/mode/gfm/gfm.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.js" integrity="sha384-/y1Nn9+QQAipbNQWU65krzJralCnuOasHncUFXGkdwntGeSvQicrYkiUBwsgUqc1" crossorigin="anonymous"></script>
 
       <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha384-dq1/gEHSxPZQ7DdrM82ID4YVol9BYyU7GbWlIwnwyPzotpoc57wDw/guX8EaYGPx" crossorigin="anonymous"></script>

--- a/src/cljs/kiwi/editor/views.cljs
+++ b/src/cljs/kiwi/editor/views.cljs
@@ -1,14 +1,118 @@
 (ns kiwi.editor.views
   (:require 
    [re-frame.core :as re-frame :refer [after dispatch dispatch-sync enrich path register-handler register-sub subscribe]]
-   [reagent.core :as reagent]))
+   [kiwi.db :as db]
+   [reagent.core :as reagent]
+   [clojure.string :as string]))
+
+(def fs (js/require "fs"))
 
 (defn- page-title-field [page]
   (let [{:keys [title]} @page]
     [:h1.post-title title]))
 
+(defn drag-enter [e local-state]
+  (let [items (.-dataTransfer.items e)]
+    (.preventDefault e)
+    (.stopPropagation e)
+    (swap! local-state update-in [:counter] inc)
+    (when (and (not (nil? items))
+               (not (= 0 (.-length items))))
+      (swap! local-state assoc :dragging true))))
+
+(defn drag-leave [e local-state]
+  (.preventDefault e)
+  (.stopPropagation e)
+  (swap! local-state update-in [:counter] dec)
+  (when (= 0 (:counter @local-state))
+    (swap! local-state assoc :dragging false)))
+
+(defn drag-over [e local-state])
+
+(defn as-img-path [file]
+  "img/" (.-name file))
+
+(defn copy-image-to-wiki! [file img-dir]
+  (fs.copyFileSync (.-path file) (str img-dir (.-name file))))
+
+(defn on-drop [e local-state editor img-dir]
+  (let [items (.-dataTransfer.files e)
+        eventCoords {:left (.-pageX e)
+                     :top (.-pageY e)}
+        coords (.coordsChar editor
+                            (clj->js eventCoords))]
+    (when (and (not (nil? items))
+               (not (= 0 (.-length items))))
+      (let [file (aget items 0)]
+        (when (string/starts-with? (.-type file) "image")
+          (.preventDefault e)
+          (.stopPropagation e)
+
+          (copy-image-to-wiki! file img-dir)
+
+          (.setCursor editor coords)
+          (.replaceRange editor
+                         (str "![](" (as-img-path file) ")")
+                         coords))))
+    (swap! local-state assoc :counter 0)
+    (swap! local-state assoc :dragging false)))
+
+;; Adds syntax highlighting for [[Internal Links]]
+(defn token-fn [^js/CodeMirror.StringStream stream state] 
+  (if-let [match (when (.match stream "[[")
+                   (loop [ch (.next stream)]
+                     (if (and (= ch "]")
+                              (= (.next stream) "]"))
+                       (do (.eat stream "]")
+                           "internal-link")
+                       (when-not (nil? ch)
+                         (recur (.next stream))))))]
+    match
+    (do
+      (while (and (.next stream) 
+                  (not (.match stream "[[" false))
+                  (not (.match stream "\n" false)))
+        1))))
+
+(defn define-kiwi-mode! []
+  (let [mode-name "kiwi"]
+    (.defineMode
+     js/CodeMirror
+     mode-name
+     (fn [config, parser-config]
+       (.overlayMode js/CodeMirror
+                     (.getMode js/CodeMirror 
+                               config 
+                               (or (.-backdrop parser-config) "gfm"))
+                     #js {:token token-fn})))
+    mode-name))
+
+(defn editor-options [contents mode-name]
+  {:value contents
+   :mode mode-name
+   :theme "default"
+   :autofocus true
+   :dragDrop true
+   :viewportMargin js/Infinity
+   :lineWrapping true
+   :extraKeys {:Tab (fn [^js/CodeMirror cm]
+                      (if (.somethingSelected cm)
+                        (.indentSelection cm "add")
+                        (.replaceSelection
+                         cm
+                         (-> cm
+                             (.getOption "indentUnit")
+                             (+ 1)
+                             js/Array
+                             (.join " "))
+                         "end"
+                         "+input")))}})
+
+
 (defn- page-content-field []
-  (let [local-state (atom {})]
+  (let [local-state (reagent/atom {})
+        wiki-root-dir @(subscribe [:wiki-root-dir])
+        img-dir (str wiki-root-dir "/" db/img-rel-path)]
     (reagent/create-class
       {:reagent-render 
        (fn []
@@ -16,58 +120,33 @@
           {:style {:width "100%" :height "500px" :display "none"}}])
        :component-did-mount 
        (fn [this]
-         (print "editor-did-mount")
          (let [{:keys [on-change contents]} (reagent/props this)
                node (reagent/dom-node this)
-               ;; Adds syntax highlighting for [[Internal Links]]
-               token-fn (fn [^js/CodeMirror.StringStream stream state] 
-                          (if-let [match (when (.match stream "[[")
-                                           (loop [ch (.next stream)]
-                                             (if (and (= ch "]") (= (.next stream) "]"))
-                                               (do (.eat stream "]")
-                                                   "internal-link")
-                                               (when-not (nil? ch) (recur (.next stream))))))]
-                            match
-                            (do
-                              (while (and (.next stream) 
-                                          (not (.match stream "[[" false))
-                                          (not (.match stream "\n" false)))
-                                1))))
-               mode (.defineMode js/CodeMirror "kiwi" 
-                                 (fn [config, parser-config]
-                                   (.overlayMode js/CodeMirror (.getMode js/CodeMirror 
-                                                                         config 
-                                                                         (or (.-backdrop parser-config) "gfm"))
-                                                 #js {:token token-fn})))
+               mode-name (define-kiwi-mode!)
                editor (js/CodeMirror #(.appendChild (.-parentNode node) %)
-                                     (clj->js
-                                      {:value contents
-                                       :mode "kiwi"
-                                       :theme "default"
-                                       :autofocus true
-                                       :viewportMargin js/Infinity
-                                       :lineWrapping true
-                                       :extraKeys {:Tab (fn [^js/CodeMirror cm]
-                                                          (if (.somethingSelected cm)
-                                                            (.indentSelection cm "add")
-                                                            (.replaceSelection
-                                                             cm
-                                                             (-> cm
-                                                                 (.getOption "indentUnit")
-                                                                 (+ 1)
-                                                                 js/Array
-                                                                 (.join " "))
-                                                             "end"
-                                                             "+input")))}
-                                       }))]
+                                     (clj->js (editor-options contents mode-name)))]
+
            (swap! local-state assoc :editor editor)
            (swap! local-state assoc :value contents)
+
+           (.on editor "drop"
+                (fn [^js/CodeMirror instance e]
+                  (on-drop e local-state instance img-dir)))
+           (.on editor "dragenter"
+                (fn [^js/CodeMirror instance e]
+                  (drag-enter e local-state)))
+           (.on editor "dragleave"
+                (fn [^js/CodeMirror instance e]
+                  (drag-leave e local-state)))
+           (.on editor "dragover"
+                (fn [^js/CodeMirror instance e]
+                  (drag-over e local-state)))
+
            (.on editor "change" 
                 (fn [^js/CodeMirror instance change-obj]
                   (let [new-value (.getValue instance)]
                     (swap! local-state assoc :value new-value)
                     (on-change new-value))))))})))
-
 
 (defn editor [{:keys [page editing]}]
   [:div#edit-container 

--- a/src/cljs/kiwi/page/markdown.cljs
+++ b/src/cljs/kiwi/page/markdown.cljs
@@ -15,7 +15,7 @@
     el))
 
 (defn img-tag->path [root-dir img-tag]
-  (let [src (string/lower-case (.-src img-tag))
+  (let [src (.-src img-tag)
         filename (path->filename src)
         path (str root-dir "/" page-db/img-rel-path filename)]
     path))

--- a/test/cljs/kiwi/tests.cljs
+++ b/test/cljs/kiwi/tests.cljs
@@ -5,7 +5,6 @@
             [kiwi.setup.events-test]
             [kiwi.editor.events-test]))
 
-
 (defn run []
   (run-tests 'kiwi.handlers-test
              'kiwi.settings.events-test


### PR DESCRIPTION
Image files can be dragged into the page editor. The image will be copied into the
wiki's img folder and a link to the copied image will be inserted into the editor
where the image file was dropped.