### PR TITLE
Upgrade electron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pom.xml.asc
 /resources/public/js/app-release
 /resources/public/js/electron-release
 /resources/public/js/electron-dev
+/resources/public/js/electron-dev-*
 /resources/public/js/out
 /resources/public/js/tests
 /Kiwi-darwin-*
@@ -24,6 +25,7 @@ pom.xml.asc
 /.env
 *.un~
 resources/main.js
+resources/main-*.js
 node_modules
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In emacs, run `M-x cljsbuild-start RET lein cljsbuild auto electron-dev RET` to 
 
 Then run `cider-jack-in-clojurescript` to run figwheel-main for electron's Renderer process.
 
-Then run `electron .` to start electron.
+Then run `npx electron .` to start electron.
 
 ### Running tests
 
@@ -15,7 +15,7 @@ Tests are run in electron using [cljs-test-display](https://github.com/bhauman/c
 After starting figwheel, open the test suite in electron by running: 
 
 ```sh
-electron resources/public/tests.html
+npx electron resources/public/tests.html
 ```
 
 Tests are automatically re-run after every hot reload.
@@ -27,7 +27,7 @@ Devcards can also be used in development.
 After starting figwheel, open devcards in electron by running: 
 
 ```sh
-electron resources/public/devcards.html 
+npx electron resources/public/devcards.html
 ```
 
 ## Release builds

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Local development
 
-In emacs, run `M-x cljsbuild-start RET lein cljsbuild auto electron-dev RET` to start compilation for electron's Main process.
+In emacs, run `M-x cljsbuild-start RET lein cljsbuild auto electron-dev electron-dev-tests electron-dev-devcards RET` to start compilation for electron's Main process.
 
 Then run `cider-jack-in-clojurescript` to run figwheel-main for electron's Renderer process.
 
@@ -15,7 +15,7 @@ Tests are run in electron using [cljs-test-display](https://github.com/bhauman/c
 After starting figwheel, open the test suite in electron by running: 
 
 ```sh
-npx electron resources/public/tests.html
+npx electron resources/main-tests.js
 ```
 
 Tests are automatically re-run after every hot reload.
@@ -27,7 +27,7 @@ Devcards can also be used in development.
 After starting figwheel, open devcards in electron by running: 
 
 ```sh
-npx electron resources/public/devcards.html
+npx electron resources/main-devcards.js
 ```
 
 ## Release builds

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "dist": "lein clean && lein cljsbuild once release electron-release && electron-builder"
   },
   "devDependencies": {
-    "electron-builder": "^19.6.3",
-    "electron-packager": "^8.7.2",
-    "electron-prebuilt": "^1.4.13"
+    "electron": "^5.0.0",
+    "electron-builder": "^20.39.0",
+    "webpack": "^4.30.0",
+    "webpack-cli": "^3.3.1"
   },
   "dependencies": {
     "electron-context-menu": "^0.9.1",
@@ -44,11 +45,11 @@
     "rehype-stringify": "^3.0.0",
     "remark": "^7.0.1",
     "remark-parse": "^3.0.1",
-    "remark-parse-yaml": "^0.0.1",
+    "remark-parse-yaml": "^0.0.2",
     "remark-rehype": "^2.0.1",
     "remark-stringify": "^3.0.1",
-    "remark-task-list": "^0.0.2",
-    "remark-wiki-link": "^0.0.1",
+    "remark-task-list": "^0.0.3",
+    "remark-wiki-link": "^0.0.3",
     "sugar-date": "^2.0.4",
     "unified": "^6.1.5",
     "unist-util-map": "^1.0.3"

--- a/project.clj
+++ b/project.clj
@@ -51,6 +51,26 @@
                                    :optimizations :simple
                                    :pretty-print true
                                    :cache-analysis true}}
+                       {:id "electron-dev-tests"
+                        :source-paths ["src/cljs/electron"]
+                        :compiler {:output-to "resources/main-tests.js"
+                                   :output-dir "resources/public/js/electron-dev-tests"
+                                   :optimizations :simple
+                                   :pretty-print true
+                                   :cache-analysis true
+                                   :closure-defines {electron.core/start-page
+                                                     "/public/tests.html"}
+                                   }}
+                       {:id "electron-dev-devcards"
+                        :source-paths ["src/cljs/electron"]
+                        :compiler {:output-to "resources/main-devcards.js"
+                                   :output-dir "resources/public/js/electron-dev-devcards"
+                                   :optimizations :simple
+                                   :pretty-print true
+                                   :cache-analysis true
+                                   :closure-defines {electron.core/start-page
+                                                     "/public/devcards.html"}
+                                   }}
                        {:id           "release"
                         :source-paths ["src/cljs/kiwi"]
                         :compiler     {:output-to     "resources/public/js/app.js"

--- a/src/cljs/electron/core.cljs
+++ b/src/cljs/electron/core.cljs
@@ -16,6 +16,8 @@
 (electron-debug (clj->js { :enabled true }))
 (def main-window (atom nil))
 
+(goog-define start-page "/public/index.html#/page/home")
+
 (defn handle-swipe [e direction]
   (let [web-contents (.-webContents ^js/electron.BrowserWindow @main-window)]
     (cond 
@@ -37,7 +39,7 @@
                                       {:nodeIntegration true}})))
 
                                         ; Path is relative to the compiled js file (main.js in our case)
-       (.loadURL ^js/electron.BrowserWindow @main-window (str "file://" js/__dirname "/public/index.html#/page/home"))
+       (.loadURL ^js/electron.BrowserWindow @main-window (str "file://" js/__dirname start-page))
        (.on ^js/electron.BrowserWindow @main-window "swipe" handle-swipe)
 
        #_ (.openDevTools (.-webContents ^js/electron.BrowserWindow @main-window))

--- a/src/cljs/electron/core.cljs
+++ b/src/cljs/electron/core.cljs
@@ -32,7 +32,9 @@
 
        (reset! main-window (browser-window.
                             (clj->js {:width 800
-                                      :height 800})))
+                                      :height 800
+                                      :webPreferences
+                                      {:nodeIntegration true}})))
 
                                         ; Path is relative to the compiled js file (main.js in our case)
        (.loadURL ^js/electron.BrowserWindow @main-window (str "file://" js/__dirname "/public/index.html#/page/home"))

--- a/src/cljs/kiwi/core.cljs
+++ b/src/cljs/kiwi/core.cljs
@@ -97,4 +97,3 @@
       (dispatch-sync [:set-route (routes/page-route {:permalink "home"})])
       (dispatch-sync [:set-route (routes/settings-route)]))
     (render)))
-


### PR DESCRIPTION
* Upgrade electron to v5.0.0

* Bump versions on some dependencies that I just published

* Make it possible to run tests and devcards with updated electron

  We re-use the same renderer process as the main app, using a compile time variable to
set the right html page to load.

  The added benefit of this is that we get the right-click context menu defined in the
renderer process!